### PR TITLE
If using Rider or VSCode, disable AddRoslynAnalyzerReferenceFeature

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,6 +6,7 @@ CsprojModifier は次の特徴を備えています:
 
 - 生成された .csproj に追加のプロジェクトを `Import` 要素で追加する
 - 生成された .csproj に Analzyer の参照を追加する
+  - 2020.2 以降で Rider または Visual Studio Code を利用している場合には無効
 
 ![](docs/images/Screen-01.png)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ CsprojModifier provides following features:
 
 - Insert additional projects as `Import` elements into generated .csproj
 - Add analyzer references to generated .csproj
+  - Disabled if you are using Rider or Visual Studio Code with Unity 2020.2 or later
 
 ![](docs/images/Screen-01.png)
 
@@ -64,6 +65,8 @@ For example, you can create the following file `YourAwesomeApp.DesignTime.props`
 [BannedApiAnalyzer](https://github.com/dotnet/roslyn-analyzers/tree/main/src/Microsoft.CodeAnalysis.BannedApiAnalyzers) expects BannedSymbols.txt as `AdditionalFiles` to be included in the project, so adding it this way will work.
 
 ### Add analyzer references to generated .csproj
+**NOTE**: Disabled this feature if you are using Rider or Visual Studio Code with Unity 2020.2 or later. Unity Editor has Roslyn Analyzer IDE support.
+
 [Roslyn analyzers are supported in Unity 2020.2 or later](https://docs.unity3d.com/Manual/roslyn-analyzers.html). However,  currently, Roslyn analyzers are not included in .csproj, and those are only used at compile time.
 
 The extension will insert `Analzyer` element into .csproj when generating the project file. As a result, you can run Roslyn Analyzer when editing code in Visual Studio. (of course, you can use it before 2020.2!)

--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/CsprojModifier.Editor.asmdef
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/CsprojModifier.Editor.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "CsprojtModifier.Editor",
+    "name": "CsprojModifier.Editor",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/CsprojModifier.Editor.asmdef
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/CsprojModifier.Editor.asmdef
@@ -8,6 +8,17 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.ide.rider",
+            "expression": "2.0.6",
+            "define": "HAS_ROSLYN_ANALZYER_SUPPORT_RIDER"
+        },
+        {
+            "name": "com.unity.ide.vscode",
+            "expression": "1.2.0",
+            "define": "HAS_ROSLYN_ANALZYER_SUPPORT_VSCODE"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/RegenerateProjectFeature.cs
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/RegenerateProjectFeature.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Unity.CodeEditor;
 using UnityEngine;
 
 namespace CsprojModifier.Editor.Features
@@ -20,21 +21,29 @@ namespace CsprojModifier.Editor.Features
 
             if (GUILayout.Button("Regenerate project files"))
             {
-                // SyncVS.Synchronizer.Sync(); (SyncVS is an internal class, so call it with Reflection)
+                if (CodeEditor.CurrentEditor.GetType().Name == "DefaultExternalCodeEditor")
+                {
+                    // SyncVS.Synchronizer.Sync(); (SyncVS is an internal class, so call it with Reflection)
 
-                var syncVsType = Type.GetType("UnityEditor.SyncVS, UnityEditor");
-                ThrowIfNull(syncVsType, "Type 'UnityEditor.SyncVS' is not found on the editor.");
+                    var syncVsType = Type.GetType("UnityEditor.SyncVS, UnityEditor");
+                    ThrowIfNull(syncVsType, "Type 'UnityEditor.SyncVS' is not found on the editor.");
 
-                var slnSynchronizerType = Type.GetType("UnityEditor.VisualStudioIntegration.SolutionSynchronizer, UnityEditor");
-                ThrowIfNull(slnSynchronizerType, "Type 'UnityEditor.VisualStudioIntegration.SolutionSynchronizer' is not found on the editor.");
+                    var slnSynchronizerType = Type.GetType("UnityEditor.VisualStudioIntegration.SolutionSynchronizer, UnityEditor");
+                    ThrowIfNull(slnSynchronizerType, "Type 'UnityEditor.VisualStudioIntegration.SolutionSynchronizer' is not found on the editor.");
 
-                var solutionSynchronizerField = syncVsType.GetField("Synchronizer", BindingFlags.Static | BindingFlags.NonPublic);
-                ThrowIfNull(solutionSynchronizerField, "Field 'Synchronizer' is not found in 'SolutionSynchronizer'.");
+                    var solutionSynchronizerField = syncVsType.GetField("Synchronizer", BindingFlags.Static | BindingFlags.NonPublic);
+                    ThrowIfNull(solutionSynchronizerField, "Field 'Synchronizer' is not found in 'SolutionSynchronizer'.");
 
-                var syncMethod = slnSynchronizerType.GetMethod("Sync", BindingFlags.Instance | BindingFlags.Public);
-                ThrowIfNull(syncMethod, "Method 'Sync' is not found in 'Synchronizer'.");
+                    var syncMethod = slnSynchronizerType.GetMethod("Sync", BindingFlags.Instance | BindingFlags.Public);
+                    ThrowIfNull(syncMethod, "Method 'Sync' is not found in 'Synchronizer'.");
 
-                syncMethod.Invoke(solutionSynchronizerField.GetValue(null), Array.Empty<object>());
+                    syncMethod.Invoke(solutionSynchronizerField.GetValue(null), Array.Empty<object>());
+                }
+                else
+                {
+                    // HACK: Make it look like a dummy file has been added.
+                    CodeEditor.CurrentEditor.SyncIfNeeded(new [] { "RegenerateProjectFeature.cs" }, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+                }
             }
         }
 


### PR DESCRIPTION
Disabled "Add Roslyn Analyzer References" feature if using Rider or Visual Studio Code with Unity 2020.2 or later.