### PR TITLE
ci: Cysharp/Actions/.github/workflows/create-release.yaml

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,17 +12,14 @@ on:
         default: false
         type: boolean
 
-env:
-  GIT_TAG: ${{ github.event.inputs.tag }}
-  DRY_RUN: ${{ github.event.inputs.dry-run }}
-
 jobs:
   update-packagejson:
     uses: Cysharp/Actions/.github/workflows/update-packagejson.yaml@main
     with:
       file-path: ./src/CsprojModifier/Assets/CsprojModifier/package.json
-      tag: ${{ github.event.inputs.tag }}
-      dry-run: ${{ fromJson(github.event.inputs.dry-run) }}
+      tag: ${{ inputs.tag }}
+      dry-run: ${{ inputs.dry-run }}
+      push-tag: false
 
   build-unity:
     needs: [update-packagejson]
@@ -45,7 +42,7 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_PACKAGE_VERSION: ${{ env.GIT_TAG }}
+          UNITY_PACKAGE_VERSION: ${{ inputs.tag }}
         with:
           projectPath: src/CsprojModifier
           unityVersion: ${{ matrix.unity }}
@@ -59,41 +56,24 @@ jobs:
       # Store artifacts.
       - uses: actions/upload-artifact@v1
         with:
-          name: CsprojModifier.${{ env.GIT_TAG }}.unitypackage
-          path: ./src/CsprojModifier/CsprojModifier.${{ env.GIT_TAG }}.unitypackage
+          name: CsprojModifier.${{ inputs.tag }}.unitypackage
+          path: ./src/CsprojModifier/CsprojModifier.${{ inputs.tag }}.unitypackage
 
+  # release
   create-release:
-    if: github.event.inputs.dry-run == 'false'
     needs: [update-packagejson, build-unity]
-    runs-on: ubuntu-latest
-    steps:
-      # Create Release
-      - uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.GIT_TAG }}
-          release_name: Ver.${{ env.GIT_TAG }}
-          commitish: ${{ needs.update-packagejson.outputs.sha }}
-          draft: true
-          prerelease: false
-
-      # Download (All) Artifacts to current directory
-      - uses: actions/download-artifact@v2
-
-      # Upload to Releases(unitypackage)
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./CsprojModifier.${{ env.GIT_TAG }}.unitypackage/CsprojModifier.${{ env.GIT_TAG }}.unitypackage
-          asset_name: CsprojModifier.${{ env.GIT_TAG }}.unitypackage
-          asset_content_type: application/octet-stream
+    uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
+    with:
+      commit-id: ${{ needs.update-packagejson.outputs.sha }}
+      dry-run: ${{ inputs.dry-run }}
+      tag: ${{ inputs.tag }}
+      nuget-push: false
+      release-upload: true
+      release-asset-path: ./CsprojModifier.${{ inputs.tag }}.unitypackage/CsprojModifier.${{ inputs.tag }}.unitypackage
+    secrets: inherit
 
   cleanup:
-    if: needs.update-packagejson.outputs.is-branch-created == 'true'
+    if: ${{ needs.update-packagejson.outputs.is-branch-created == 'true' }}
     needs: [update-packagejson, build-unity]
     uses: Cysharp/Actions/.github/workflows/clean-packagejson-branch.yaml@main
     with:


### PR DESCRIPTION
## tl;dr;

Replace create-release with `Cysharp/Actions/.github/workflows/create-release.yaml`.

This brings central managed release flow control.

see: https://github.com/Cysharp/CsprojModifier/actions/runs/7813684825