### PR TITLE
Fix NullReferenceException in InsertAdditionalImportFeature.cs in Unity 2022

### DIFF
--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/InsertAdditionalImportFeature.cs
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/InsertAdditionalImportFeature.cs
@@ -145,7 +145,7 @@ namespace CsprojModifier.Editor.Features
                 var baseDir = Path.GetDirectoryName(path);
                 var xDoc = XDocument.Parse(content);
                 var nsMsbuild = (XNamespace)"http://schemas.microsoft.com/developer/msbuild/2003";
-                var projectE = xDoc.Element(nsMsbuild + "Project");
+                var projectE = xDoc.Element(nsMsbuild + "Project") ?? xDoc.Element("Project");
 
                 foreach (var target in settings.AdditionalImports)
                 {

--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/InsertAdditionalImportFeature.cs
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/InsertAdditionalImportFeature.cs
@@ -144,8 +144,7 @@ namespace CsprojModifier.Editor.Features
 
                 var baseDir = Path.GetDirectoryName(path);
                 var xDoc = XDocument.Parse(content);
-                var nsMsbuild = (XNamespace)"http://schemas.microsoft.com/developer/msbuild/2003";
-                var projectE = xDoc.Element(nsMsbuild + "Project") ?? xDoc.Element("Project");
+                var projectE = xDoc.Element("Project");
 
                 foreach (var target in settings.AdditionalImports)
                 {
@@ -154,11 +153,11 @@ namespace CsprojModifier.Editor.Features
                     if (target.Position == ImportProjectPosition.Append)
                     {
                         projectE.Add(new XComment($"{target.Path}:{hash}"));
-                        projectE.Add(new XElement(nsMsbuild + "Import", new XAttribute("Project", target.Path)));
+                        projectE.Add(new XElement("Import", new XAttribute("Project", target.Path)));
                     }
                     else if (target.Position == ImportProjectPosition.Prepend)
                     {
-                        projectE.AddFirst(new XElement(nsMsbuild + "Import", new XAttribute("Project", target.Path)));
+                        projectE.AddFirst(new XElement("Import", new XAttribute("Project", target.Path)));
                         projectE.AddFirst(new XComment($"{target.Path}:{hash}"));
                     }
                     else if (target.Position == ImportProjectPosition.AppendContent)


### PR DESCRIPTION
## Problem

![image](https://github.com/Cysharp/CsprojModifier/assets/22608356/14b3b09d-3bcf-418d-a290-0756c3086df3)

This problem occurs when using CsprojModifier with Unity 2022.

In the following code, projectE was null.

```cs
var nsMsbuild = (XNamespace)"http://schemas.microsoft.com/developer/msbuild/2003";
var projectE = xDoc.Element(nsMsbuild + "Project");
```

## Fix

As shown below, the xmlns attribute was missing from the Unity 2022 csproj file.

![image](https://github.com/Cysharp/CsprojModifier/assets/22608356/6b69d414-df70-4928-a8ba-229ca1a87ef5)

In light of this, I have fixed it so that it works correctly even when the xmlns attribute is missing.

```cs
var nsMsbuild = (XNamespace)"http://schemas.microsoft.com/developer/msbuild/2003";
var projectE = xDoc.Element(nsMsbuild + "Project") ?? xDoc.Element("Project");
```