### PR TITLE
ci: change upload-artifact & download-artifact to Cysharp/Actions

### DIFF
--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -53,3 +53,4 @@ jobs:
         with:
           name: CsprojModifier.${{ matrix.unity }}.unitypackage.zip
           path: ./src/CsprojModifier/*.unitypackage
+          retention-days: 1

--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -49,7 +49,7 @@ jobs:
           directory: src/CsprojModifier
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: CsprojModifier.${{ matrix.unity }}.unitypackage.zip
           path: ./src/CsprojModifier/*.unitypackage

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -65,7 +65,7 @@ jobs:
           directory: src/CsprojModifier
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v1
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: CsprojModifier.${{ inputs.tag }}.unitypackage
           path: ./src/CsprojModifier/CsprojModifier.${{ inputs.tag }}.unitypackage

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           name: CsprojModifier.${{ inputs.tag }}.unitypackage
           path: ./src/CsprojModifier/CsprojModifier.${{ inputs.tag }}.unitypackage
+          retention-days: 1
 
   # release
   create-release:


### PR DESCRIPTION
## tl;dr;

To handle actions/upload-artifact & download-artifact version consistency, manage actions version via Central Maanged Cysharp/Actions.
