### PR TITLE
fix: Add support for both classic and SDK-style csproj formats

### DIFF
--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/InsertAdditionalImportFeature.cs
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/InsertAdditionalImportFeature.cs
@@ -145,7 +145,7 @@ namespace CsprojModifier.Editor.Features
                 var baseDir = Path.GetDirectoryName(path);
                 var xDoc = XDocument.Parse(content);
                 var nsMsbuild = (XNamespace)"http://schemas.microsoft.com/developer/msbuild/2003";
-                var projectE = xDoc.Element(nsMsbuild + "Project");
+                var projectE = xDoc.Element(nsMsbuild + "Project") ?? xDoc.Element("Project");
 
                 foreach (var target in settings.AdditionalImports)
                 {

--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/InsertAdditionalImportFeature.cs
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/InsertAdditionalImportFeature.cs
@@ -144,8 +144,7 @@ namespace CsprojModifier.Editor.Features
 
                 var baseDir = Path.GetDirectoryName(path);
                 var xDoc = XDocument.Parse(content);
-                var nsMsbuild = (XNamespace)"http://schemas.microsoft.com/developer/msbuild/2003";
-                var projectE = xDoc.Element(nsMsbuild + "Project") ?? xDoc.Element("Project");
+                var projectE = xDoc.Element("Project");
 
                 foreach (var target in settings.AdditionalImports)
                 {
@@ -154,11 +153,11 @@ namespace CsprojModifier.Editor.Features
                     if (target.Position == ImportProjectPosition.Append)
                     {
                         projectE.Add(new XComment($"{target.Path}:{hash}"));
-                        projectE.Add(new XElement(nsMsbuild + "Import", new XAttribute("Project", target.Path)));
+                        projectE.Add(new XElement("Import", new XAttribute("Project", target.Path)));
                     }
                     else if (target.Position == ImportProjectPosition.Prepend)
                     {
-                        projectE.AddFirst(new XElement(nsMsbuild + "Import", new XAttribute("Project", target.Path)));
+                        projectE.AddFirst(new XElement("Import", new XAttribute("Project", target.Path)));
                         projectE.AddFirst(new XComment($"{target.Path}:{hash}"));
                     }
                     else if (target.Position == ImportProjectPosition.AppendContent)


### PR DESCRIPTION
Fixed #19
This is a follow-up to PR: #12

Updated the code to work with or without an `xmlns` attribute on the `Project` element.
A default namespace is used to prevent `xmlns=""` from being added to new `Import` elements.
