### PR TITLE
When using Visual Studio as script editor, hide the Analyzer Support checkbox.

### DIFF
--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/CsprojModifier.Editor.asmdef
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/CsprojModifier.Editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "CsprojModifier.Editor",
+    "rootNamespace": "",
     "references": [],
     "includePlatforms": [
         "Editor"
@@ -25,6 +26,11 @@
             "name": "com.unity.ide.vscode",
             "expression": "1.2.0",
             "define": "HAS_ROSLYN_ANALZYER_SUPPORT_VSCODE"
+        },
+        {
+            "name": "com.unity.ide.visualstudio",
+            "expression": "2.0.0",
+            "define": "HAS_ROSLYN_ANALZYER_SUPPORT_VS"
         }
     ],
     "noEngineReferences": false

--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/AddAnalyzerReferenceFeature.cs
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/AddAnalyzerReferenceFeature.cs
@@ -148,10 +148,10 @@ namespace CsprojModifier.Editor.Features
                 get
                 {
 
-#if UNITY_2020_2_OR_NEWER && (HAS_ROSLYN_ANALZYER_SUPPORT_RIDER || HAS_ROSLYN_ANALZYER_SUPPORT_VSCODE)
-                    // The editor extension for 'Rider' or 'Visual Studio Code' has the functionality to add Roslyn analyzer references.
+#if UNITY_2020_2_OR_NEWER && (HAS_ROSLYN_ANALZYER_SUPPORT_RIDER || HAS_ROSLYN_ANALZYER_SUPPORT_VSCODE || HAS_ROSLYN_ANALZYER_SUPPORT_VS)
+                    // The editor extension for 'Rider', 'Visual Studio Code' and 'Visual Studio' has the functionality to add Roslyn analyzer references.
                     var codeEditorType = Unity.CodeEditor.CodeEditor.CurrentEditor.GetType();
-                    if (codeEditorType.Name == "VSCodeScriptEditor" || codeEditorType.Name == "RiderScriptEditor")
+                    if (codeEditorType.Name == "VSCodeScriptEditor" || codeEditorType.Name == "RiderScriptEditor" || codeEditorType.Name == "VisualStudioEditor")
                     {
                         return true;
                     }


### PR DESCRIPTION
Starting with version 2.0.0 of com.unity.ide.visualstudio, the Roslyn analyzer is natively supported in Unity 2020.3+.