### PR TITLE
Version control friendly settings

### DIFF
--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/CsprojModifierSettings.cs
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/CsprojModifierSettings.cs
@@ -56,7 +56,7 @@ namespace CsprojModifier.Editor
 
         public void Save()
         {
-            File.WriteAllText(SettingsPath, JsonUtility.ToJson(_instance));
+            File.WriteAllText(SettingsPath, JsonUtility.ToJson(_instance, true));
         }
     }
 


### PR DESCRIPTION
Enabled pretty print to make the `CsprojModifierSettings.json` source control friendly and easier to read.