### PR TITLE
Cache analyzers in Project Settings rather than getting them every frame

### DIFF
--- a/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/AddAnalyzerReferenceFeature.cs
+++ b/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/AddAnalyzerReferenceFeature.cs
@@ -15,6 +15,7 @@ namespace CsprojModifier.Editor.Features
     public class AddAnalyzerReferenceFeature : CsprojModifierFeatureBase
     {
         private ReorderableList _reorderableListAdditionalAddAnalyzerProjects;
+        private IReadOnlyList<string> _analyzers = GetAnalyzers();
 
         public override void Initialize()
         {
@@ -127,14 +128,17 @@ namespace CsprojModifier.Editor.Features
             {
                 using (new EditorGUILayout.VerticalScope(GUI.skin.box))
                 {
-                    var analyzers = GetAnalyzers();
-                    foreach (var analyzer in analyzers)
+                    foreach (var analyzer in _analyzers)
                     {
                         EditorGUILayout.LabelField(analyzer, EditorStyles.label);
                     }
                 }
                 EditorGUILayout.HelpBox("Analyzer must be labeled as 'RoslynAnalyzer'", MessageType.Info);
 
+                if (GUILayout.Button("Rescan Roslyn Analyzers"))
+                {
+                    _analyzers = GetAnalyzers();
+                }
                 EditorGUILayout.LabelField("The project to be added for Roslyn Analyzer references.");
                 _reorderableListAdditionalAddAnalyzerProjects.DoLayoutList();
             }


### PR DESCRIPTION
https://github.com/Cysharp/CsprojModifier/blob/e82080dac67f22fa0ef0b7c0aceadda92df76ec3/src/CsprojModifier/Assets/CsprojModifier/Editor/Features/AddAnalyzerReferenceFeature.cs#L109-L135

It's VERY slow to invoke `GetAnalyzers()` in every `OnGUI` call, when the project is large.